### PR TITLE
Add dub support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 bin/
+doc/
+
+.dub/
+dub.selections.json
+
+*.o
+*.a
+*.exe

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,13 @@
+{
+	"name": "harbored",
+	"targetPath": "bin",
+	"targetType": "executable",
+	"description": "Documentation generator for D",
+	"copyright": "Copyright © 2014-2015, Economic Modeling Specialists, Intl.",
+	"authors": [ "Brian Schott" ],
+	"stringImportPaths": [ "strings" ],
+	"dependencies": {
+		"libddoc": { "path": "./libddoc" },
+		"libdparse": { "path": "./libdparse" }
+	}
+}


### PR DESCRIPTION
As simple as it gets.
Note: This won't compile directly unless you update the dependency to libddoc (because dub default to warnings as error), and you also need to fix unittests not compiling (visitor:661).